### PR TITLE
Expand data type validation based on "config" sheet

### DIFF
--- a/lib/spreadsheet.ts
+++ b/lib/spreadsheet.ts
@@ -92,22 +92,27 @@ export function writeToSheet(
  * @returns Raw sheet content as nested array.
  */
 export function readGoogleSheetTab(tabName: string): SheetContents {
-	const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
-	const tab = spreadsheet.getSheetByName(tabName);
-	const rawData = tab
-		?.getRange(1, 1, tab.getMaxRows(), tab.getMaxColumns())
-		?.getValues();
 	const {
 		validateSheet,
+		ValidationError,
 	} = require('./validation') as typeof import('./validation');
+	const spreadsheet = SpreadsheetApp.getActiveSpreadsheet();
+	const tab = spreadsheet.getSheetByName(tabName);
+	if (!tab) {
+		throw new ValidationError(
+			`Tab "${tabName}" was not found in spreadsheet "${spreadsheet.getName()}"`,
+		);
+	}
+	const rawData =
+		tab?.getRange(1, 1, tab.getMaxRows(), tab.getMaxColumns())?.getValues() ||
+		[];
 	const sheetConfig: ConfigByColumn | undefined = validateSheet(
 		spreadsheet,
 		tab,
-		tabName,
 		rawData,
 	);
 	const sheetContents: SheetContents = {
-		data: rawData || [],
+		data: rawData,
 		config: sheetConfig,
 	};
 	return sheetContents;

--- a/lib/validation.ts
+++ b/lib/validation.ts
@@ -1,7 +1,13 @@
-class ValidationError extends Error {}
-
 import { FieldsWithOptionalFunction, parseRange } from './parse';
 
+export class ValidationError extends Error {}
+
+export const TRUE_VALUES = ['true', 'yes'];
+export const FALSE_VALUES = ['false', 'no'];
+export const BOOL_VALUES = [...TRUE_VALUES, ...FALSE_VALUES];
+export const GSHEET_TYPES = ['string', 'number', 'date', 'boolean'];
+
+/** Fields of the special `config` sheet used for data validation. */
 const configFields: FieldsWithOptionalFunction = [
 	['Sheet name', 'sheetName'],
 	['Column name', 'columnName'],
@@ -10,18 +16,85 @@ const configFields: FieldsWithOptionalFunction = [
 	[
 		'Required',
 		'required',
-		(value) => typeof value !== 'string' || value.toLowerCase() !== 'false',
+		(value) =>
+			typeof value === 'boolean'
+				? value
+				: typeof value !== 'string' || !FALSE_VALUES.includes(value),
 	],
 ];
 
+/**
+ * metaConfig: A hardcoded `config` sheet that specifies the data types
+ * of the config sheet itself, in order to validate the config sheet.
+ */
+const metaConfig = [
+	['Sheet name', 'Column name', 'Identifier', 'Type', 'Required'],
+	['config', 'Sheet name', 'sheetName', 'string', 'true'],
+	['config', 'Column name', 'columnName', 'string', 'true'],
+	['config', 'Identifier', 'identifier', 'string', 'true'],
+	['config', 'Type', 'type', 'string', 'true'],
+	['config', 'Required', 'required', 'boolean', 'true'],
+];
+
+/**
+ * `config` sheet caching to speed up validation of multiple sheets
+ * in the same script execution. Also avoids loading the config sheet
+ * twice during recursive validation of the config sheet itself.
+ */
+class CachedConfig {
+	constructor(
+		public configSheet: GoogleAppsScript.Spreadsheet.Sheet | null = null,
+		public configData: any[][] = [],
+		public parsedConfig: ParsedConfig[] = [],
+	) {}
+
+	static bySpreadsheetId: {
+		[spreadsheetId: string]: CachedConfig;
+	} = {};
+
+	get(
+		spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet,
+		spreadsheetId = spreadsheet.getId(),
+	): CachedConfig {
+		let cachedConfig = CachedConfig.bySpreadsheetId[spreadsheetId];
+		if (!cachedConfig) {
+			const configSheet = spreadsheet.getSheetByName('config');
+			cachedConfig = new CachedConfig(configSheet);
+			CachedConfig.bySpreadsheetId[spreadsheetId] = cachedConfig;
+			if (configSheet) {
+				cachedConfig.configData = configSheet
+					.getRange(1, 1, configSheet.getMaxRows(), configFields.length)
+					.getValues();
+				cachedConfig.parsedConfig = parseRange(
+					configFields,
+					cachedConfig.configData,
+				);
+				// note that validateConfigSheetItself() will recursively call
+				// this get() method, but will then get a cache hit.
+				validateConfigSheetItself(
+					spreadsheet,
+					configSheet,
+					cachedConfig.configData,
+					cachedConfig.parsedConfig,
+				);
+			}
+		}
+		return cachedConfig;
+	}
+}
+
+const configCache = new CachedConfig();
+
+/** Parsed representation of the `config` sheet itself */
 interface ParsedConfig {
 	sheetName: string;
 	columnName: string;
 	identifier: string;
 	type: string;
-	required: boolean;
+	required: string;
 }
 
+/** `config` details for a specific column of the sheet to validate */
 interface ColumnTypeInfo {
 	columnName: string;
 	identifier: string;
@@ -33,64 +106,144 @@ export interface ConfigByColumn {
 	[columnName: string]: ColumnTypeInfo;
 }
 
+/**
+ * Validate the given sheet (tab) against the "schema" defined in a special
+ * `config` sheet/tab in the same spreadsheet.
+ * @param spreadsheet The Spreadsheet object containing the sheet to validate
+ * @param sheet The Sheet object (tab) to validate
+ * @param dataToValidate Sheet contents as a nested array (as produced by
+ * Sheet.getRange().getValues())
+ * @returns ConfigByColumn object if a `config` sheet exists
+ */
 export function validateSheet(
 	spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet,
-	sheet: GoogleAppsScript.Spreadsheet.Sheet | null,
-	sheetName: string,
-	_dataToValidate?: any[][],
-) {
-	return getConfigForSheet(spreadsheet, sheet, sheetName);
-	// TODO: validate dataToValidate :-)
+	sheet: GoogleAppsScript.Spreadsheet.Sheet,
+	dataToValidate: any[][],
+): ConfigByColumn | undefined {
+	const sheetName = sheet.getName();
+	const configByColumn = getConfigForSheet(spreadsheet, sheetName);
+	if (!configByColumn) {
+		return;
+	}
+	let endOfSheet = false;
+	let header: string[] = []; // column names
+	for (const row of dataToValidate) {
+		endOfSheet ||= isBlank(row[0]);
+		if (endOfSheet) {
+			if (!isBlank(row[0])) {
+				throw new ValidationError(`\
+Validation error: non-empty cell found after empty cell in first column of sheet "${sheetName}".
+An empty cell in the first column is used to indicate the end of the sheet.`);
+			}
+			continue;
+		}
+		if (!header.length) {
+			validateHeader(row, configByColumn, sheetName);
+			header = row;
+			continue;
+		}
+		validateRow(row, header, configByColumn, sheetName);
+	}
+
+	return configByColumn;
 }
 
+/** Validate the header (row of column names) of a sheet */
+function validateHeader(
+	row: any[],
+	configByColumn: ConfigByColumn,
+	sheetName: string,
+) {
+	const expectedCols = Object.keys(configByColumn);
+	if (row.length !== expectedCols.length) {
+		throw new ValidationError(`\
+Validation error: Expected a header row to contain ${
+			expectedCols.length
+		} column names,
+but found ${row.length} column names instead.
+Expected column names: "${expectedCols.sort().join('", "')}"
+Found column names: "${row.sort().join('", "')}"`);
+	}
+	for (const col of row) {
+		if (!configByColumn[col]) {
+			throw new ValidationError(`\
+Validation error: column "${col}" of sheet "${sheetName}" not found in "config" sheet.
+Expected column names: "${expectedCols.sort().join('", "')}"
+Found column names: "${row.sort().join('", "')}"`);
+		}
+	}
+}
+
+/** Validate a data row (not the header) of a sheet */
+function validateRow(
+	row: any[],
+	header: any[],
+	configByColumn: ConfigByColumn,
+	sheetName: string,
+) {
+	let colIndex = 0;
+	for (const col of row) {
+		const colName = header[colIndex++];
+		const colType = typeof col;
+		const config = configByColumn[colName];
+
+		if (isBlank(col)) {
+			if (config.required) {
+				throw new ValidationError(`\
+Validation error: blank cell found in column "${colName}" of sheet "${sheetName}",
+but the "config" sheet specifies that a value is required.`);
+			}
+			continue; // empty and not required
+		}
+
+		if (config.type === 'boolean') {
+			parseBoolean(col, `in column "${colName}" of sheet "${sheetName}"`);
+		} else if (config.type === 'date') {
+			if (!(col instanceof Date)) {
+				const foundType =
+					colType === 'object' ? col?.constructor?.name || 'object' : colType;
+				throw new ValidationError(`\
+Validation error: mismatched data type in column "${colName}" of sheet "${sheetName}".
+Expected "Date", found "${foundType}".
+Cell value: "${col}"`);
+			}
+		} else if (config.type !== colType) {
+			throw new ValidationError(`\
+Validation error: mismatched data type in column "${colName}" of sheet "${sheetName}".
+Expected "${config.type}", found "${colType}".
+Cell value: "${col}"`);
+		}
+	}
+}
+
+/** Compute a ConfigByColumn object for the given sheetName (tab name). */
 export function getConfigForSheet(
 	spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet,
-	sheet: GoogleAppsScript.Spreadsheet.Sheet | null,
 	sheetName: string,
 ): ConfigByColumn | undefined {
-	if (!sheet) {
-		throw new ValidationError(
-			`Sheet "${sheetName}" was not found in spreadsheet "${spreadsheet.getName()}"`,
-		);
-	}
-	if (!sheetName || sheetName !== sheet.getName()) {
-		throw new Error(`\
-Validation inconsistency error: "${sheetName}" does not match "${sheet.getName()}".
-This is likely to be a programming bug.`);
-	}
-
-	const configSheet = spreadsheet.getSheetByName('config');
-	if (!configSheet) {
+	const cachedConfig = configCache.get(spreadsheet);
+	if (!cachedConfig.configSheet) {
 		console.log(`\
 Warning: Skipping data type validation of "${spreadsheet.getName()}"
 because it does not contain a "config" sheet/tab.`);
 		return;
 	}
-	const configData = configSheet
-		.getRange(1, 1, configSheet.getMaxRows(), configFields.length)
-		.getValues();
-	const parsedConfig: ParsedConfig[] = parseRange(configFields, configData);
-
-	// Even though we are only meant to validate sheetName, we insist
-	// that all sheet names found in the config sheet must exist.
-	const sheetNames = new Set(parsedConfig.map((config) => config.sheetName));
-	for (const name of sheetNames) {
-		if (!spreadsheet.getSheetByName(name)) {
-			throw new ValidationError(`\
-Config data validation exists for sheet "${name}", but this sheet was
-not found in spreadsheet "${spreadsheet.getName()}"`);
-		}
-	}
-
 	const configByColumn: ConfigByColumn = {};
+	const parsedConfig: ParsedConfig[] =
+		sheetName === 'config'
+			? parseRange(configFields, metaConfig)
+			: cachedConfig.parsedConfig;
 
 	for (const configObj of parsedConfig) {
 		if (configObj.sheetName === sheetName) {
 			configByColumn[configObj.columnName] = {
-				columnName: configObj.columnName,
-				identifier: configObj.identifier,
-				type: configObj.type,
-				required: configObj.required,
+				columnName: configObj.columnName.trim(),
+				identifier: configObj.identifier.trim(),
+				type: configObj.type.trim().toLowerCase(),
+				required: parseBoolean(
+					configObj.required,
+					`in column "Required" of sheet "config"`,
+				),
 			};
 		}
 	}
@@ -101,4 +254,67 @@ listed in the "config" sheet/tab.`);
 		return;
 	}
 	return configByColumn;
+}
+
+/**
+ * Validate the `config` sheet itself, by recursively calling
+ * validateSheet() and then performing a few extra checks.
+ */
+function validateConfigSheetItself(
+	spreadsheet: GoogleAppsScript.Spreadsheet.Spreadsheet,
+	configSheet: GoogleAppsScript.Spreadsheet.Sheet,
+	configData: any[][],
+	parsedConfig: ParsedConfig[],
+) {
+	validateSheet(spreadsheet, configSheet, configData);
+	const sheetNames: Set<string> = new Set();
+
+	for (const configObj of parsedConfig) {
+		sheetNames.add(configObj.sheetName);
+		if (!GSHEET_TYPES.includes(configObj.type.trim().toLowerCase())) {
+			throw new ValidationError(`\
+Uknown data type specification "${configObj.type}" in "config" sheet of
+spreadsheet "${spreadsheet.getName()}".
+Known data types are: "${GSHEET_TYPES.join('", ')}"`);
+		}
+	}
+	// Validate that all sheet names found in the config sheet exist.
+	for (const name of sheetNames) {
+		if (!spreadsheet.getSheetByName(name)) {
+			throw new ValidationError(`\
+Config data validation exists for sheet "${name}", but this sheet was
+not found in spreadsheet "${spreadsheet.getName()}"`);
+		}
+	}
+}
+
+/** Validate and parse true/false/yes/no as a boolean */
+function parseBoolean(value: any, context?: string): boolean {
+	if (typeof value === 'boolean') {
+		return value;
+	}
+	function fail() {
+		const msg = [
+			`\
+Validation error: Invalid boolean value representation: "${value}"
+Valid representations are one of: "${BOOL_VALUES.join('", "')}"`,
+		];
+		if (context) {
+			msg.push(context);
+		}
+		throw new ValidationError(msg.join('\n'));
+	}
+	if (typeof value !== 'string') {
+		fail();
+	}
+	const normalized = value.toLowerCase();
+	if (!BOOL_VALUES.includes(normalized)) {
+		fail();
+	}
+	return TRUE_VALUES.includes(normalized);
+}
+
+/** Determine whether a cell value is blank */
+function isBlank(value: any) {
+	return value == null || (typeof value === 'string' && value.trim() === '');
 }


### PR DESCRIPTION
This PR replaces `// TODO: validate dataToValidate` in `validateSheet()` with actual data validation code. 😁 

Further "to dos" (for other PRs) include ~~code documentation~~ ✔, ~~perhaps some refactoring to break down large functions into smaller ones~~ ✔, and more testing, including adding unit tests. Testing so far was limited, so there may be bugs hiding under the surface. 🐛 

Change-type: minor