### PR TITLE
Add automated typedoc site generation

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -1,0 +1,37 @@
+# This workflow will install the dependencies and then build and deploy the
+# TypeScript documentation website to the docs branch.
+
+# This file is auto-synced from product-os/jellyfish-config/sync/.github/workflows/publish-docs.yml
+# and should only be edited there!
+
+name: Publish Documentation
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  publish-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+
+      - name: Install NPM dependencies
+        run: npm i
+
+      - name: Generate docs
+        run: npm run doc
+
+      - name: Publish generated docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs
+          publish_branch: docs

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+# Doc files should not be committed. They are generated using
+# the command 'npm run doc' and committed to the root of the
+# 'docs' branch.
+docs/

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "test:node": "mocha -r ts-node/register --reporter spec tests/**/*.spec.ts",
     "test": "npm run build && npm run test:node",
     "test:fast": "npm run build && npm run test:node",
-    "prepack": "npm run build"
+    "prepack": "npm run build",
+    "doc": "typedoc lib/ && touch docs/.nojekyll"
   },
   "devDependencies": {
     "@balena/lint": "^5.4.1",
@@ -45,6 +46,7 @@
     "mocha": "^8.3.2",
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
+    "typedoc": "^0.22.12",
     "typescript": "^4.2.3"
   },
   "versionist": {


### PR DESCRIPTION
This change adds a GitHub action that uses TypeDoc to automatically
generate API documentation and publish it with GitHub pages.

Change-type: patch
Signed-off-by: Lucian Buzzo <lucian.buzzo@gmail.com>